### PR TITLE
feat: support image input

### DIFF
--- a/app/images.py
+++ b/app/images.py
@@ -1,0 +1,33 @@
+import base64
+import os
+import tempfile
+import urllib.parse
+import urllib.request
+import mimetypes
+
+from .config import settings
+
+
+def save_image_to_temp(url: str) -> str:
+    """Fetch an image URL or data URI to a temporary file and return its path."""
+    try:
+        if url.startswith("data:"):
+            header, b64data = url.split(",", 1)
+            mime = header.split(";")[0][5:] if header.startswith("data:") else "image"
+            suffix = mimetypes.guess_extension(mime) or ".png"
+            data = base64.b64decode(b64data)
+        else:
+            parsed = urllib.parse.urlparse(url)
+            if parsed.scheme == "file":
+                with open(urllib.request.url2pathname(parsed.path), "rb") as fh:
+                    data = fh.read()
+                suffix = os.path.splitext(parsed.path)[1] or ".png"
+            else:
+                with urllib.request.urlopen(url) as resp:
+                    data = resp.read()
+                suffix = os.path.splitext(parsed.path)[1] or ".png"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix, dir=settings.codex_workdir) as f:
+            f.write(data)
+            return f.name
+    except Exception as e:
+        raise ValueError(f"failed to load image: {e}")

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -36,7 +36,7 @@ Notes
 - `POST /v1/chat/completions`
   - Input (subset)
     - `model`: optional; defaults to `codex-cli`
-    - `messages`: OpenAI format (`system`/`user`/`assistant`)
+  - `messages`: OpenAI format (`system`/`user`/`assistant`). User messages may include `input_image` parts.
     - `stream`: `true` for SSE streaming
     - `temperature`, `max_tokens`: accepted but ignored for the initial version
   - Output (non‑stream)
@@ -63,6 +63,21 @@ resp = client.chat.completions.create(
     messages=[
         {"role": "system", "content": "You are a helpful coding agent."},
         {"role": "user", "content": "Say hello and exit."},
+    ],
+)
+print(resp.choices[0].message.content)
+
+# Image input
+resp = client.chat.completions.create(
+    model="codex-cli",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Describe this image"},
+                {"type": "input_image", "image_url": {"url": "https://example.com/cat.png"}},
+            ],
+        }
     ],
 )
 print(resp.choices[0].message.content)
@@ -252,7 +267,7 @@ git submodule update --remote submodules/codex
 
 ## Limitations (initial)
 
-- No tool/function calling; no image/audio
+ - No tool/function calling; no audio
 - No strict token accounting; no multi‑threading
 - CLI output format can evolve; we parse both JSON and text to remain resilient
 

--- a/docs/RESPONSES_API_PLAN.ja.md
+++ b/docs/RESPONSES_API_PLAN.ja.md
@@ -22,22 +22,22 @@
 - エラー時: `response.error` を送出し、その後 `[DONE]` を送る。
 
 フェーズC（互換拡張）
-- 入力 `input` のバリアント追加（chat-like 構造、`input_text` 配列など）。
+- 入力 `input` のバリアント追加（chat-like 構造、`input_text` 配列、`input_image` パーツなど）。
 - `reasoning.effort` → Codex の `model_reasoning_effort` にマップ。
 - `temperature` / `max_output_tokens` は受けるが無視（現行どおり）。
-- 未対応明示（将来検討）: ツール呼び出し、画像/音声、structured output（JSON schema など）、並列スレッド。
+- 未対応明示（将来検討）: ツール呼び出し、音声、structured output（JSON schema など）、並列スレッド。
 
 ## リクエスト変換（最小）
 
 受け入れ（順に判定）
 - Case 1: `input` が string → `messages=[{"role":"user","content": input}]`
-- Case 2: `input` が配列で、各要素が `{type:"input_text", text: string}` → text を結合して 1 ユーザーメッセージへ
+ - Case 2: `input` が配列で、各要素が `{type:"input_text"|"input_image", ...}` → 1 ユーザーメッセージとして扱う（`input_text` は結合、`input_image` は画像として転送）
 - Case 3: `input` が配列で、各要素が `{role, content}` を持つ（chat-like）→ そのまま `messages` として利用
 
 オプション・マッピング
 - `reasoning.effort`（`minimal|low|medium|high`）→ `x_codex.reasoning_effort`
 - `stream: true/false` → SSE 出力の有無
-- 以下は一旦未対応（受け取って無視／400 にしない）：`instructions`、`modalities`、`audio`、`image`、`tools`、`metadata`、`text.format`（Structured Output）
+  - 以下は一旦未対応（受け取って無視／400 にしない）：`instructions`、`modalities`、`audio`、`tools`、`metadata`、`text.format`（Structured Output）
 
 ## レスポンス構造（非ストリーム）
 


### PR DESCRIPTION
## Summary
- allow image parts in messages and Responses API
- pipe downloaded images to `codex exec`
- document image support and adjust limitations

## Testing
- `python -m py_compile app/*.py`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7cc38be98832fb7704ee6088920da