### PR TITLE
Add dynamic Codex model discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,8 @@ CODEX_PATH=codex
 # `Failed to create CODEX_WORKDIR ... Read-only file system` at runtime.
 CODEX_WORKDIR=/workspace
 
-# Optional: force a specific model (e.g. o3, o4-mini, gpt-5)
-CODEX_MODEL=
-
+# NOTE: Model selection is now automatic at startup. Remove any legacy CODEX_MODEL
+# definition; the server will ignore it.
 
 # Sandbox mode for Codex CLI (read-only | workspace-write | danger-full-access)
 CODEX_SANDBOX_MODE=read-only

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,7 @@ mkdir -p ~/.codex
 cp docs/examples/codex-config.example.toml ~/.codex/config.toml
 ```
 
-OpenAI の gpt-5 モデルを使うには、（APIキー運用時は）`OPENAI_API_KEY` を環境変数として設定し、`.env` などで `CODEX_MODEL=gpt-5` を指定します。OAuth運用時は `OPENAI_API_KEY` は必須ではありません。
+OpenAI の gpt-5 モデルを使うには、（APIキー運用時は）Codex CLI 側で該当プロバイダーの資格情報を設定してください。このラッパーは起動時に `codex models list` を実行して利用可能なモデル名を自動検出します。利用可能なモデル名は `GET /v1/models` で確認できます。OAuth運用時は `OPENAI_API_KEY` は必須ではありません。
 
 5) 環境変数の設定（.env 対応）
 
@@ -111,7 +111,7 @@ Responses API 互換は最小実装済み（非ストリーム/ストリーム�
 - CODEX_PATH: `codex` バイナリのパス。既定値は `codex`。
 - CODEX_WORKDIR: Codex 実行時の作業ディレクトリ (`cwd`)。既定値は `/workspace`。
   - サーバープロセスから書き込み可能なパスを指定してください。読み取り専用パスの場合は `Failed to create CODEX_WORKDIR ... Read-only file system` エラーになります。
-- CODEX_MODEL: Codex の `model` に渡す文字列（例: `o3`, `o4-mini`, `gpt-5`）。利用する `model_provider` がサポートするモデル名である必要があります。
+- CODEX_MODEL: **廃止**。モデル選択は自動化されており、この変数を設定しても無視され（起動時に警告が出力されます）。
 - CODEX_SANDBOX_MODE: サンドボックスモード。`read-only` / `workspace-write` / `danger-full-access` のいずれか。
   - `workspace-write` の場合、API リクエストで `x_codex.network_access` が指定されると `--config sandbox_workspace_write='{ network_access = <true|false> }'` を付与します。
 - CODEX_REASONING_EFFORT: 推論強度。`minimal` / `low` / `medium` / `high`（既定は `medium`）。

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mkdir -p ~/.codex
 cp docs/examples/codex-config.example.toml ~/.codex/config.toml
 ```
 
-To use OpenAI’s gpt‑5 model (when using API‑key mode), set `OPENAI_API_KEY` as an environment variable and set `.env` variable `CODEX_MODEL=gpt-5`. For OAuth, `OPENAI_API_KEY` is not required.
+To use OpenAI’s gpt‑5 model (when using API‑key mode), configure the Codex CLI with the appropriate provider credentials. This wrapper now queries the CLI for available models at startup, so call `GET /v1/models` to discover the names you can use. For OAuth, `OPENAI_API_KEY` is not required.
 
 5) Environment Variables (.env supported)
 
@@ -107,7 +107,7 @@ This server reads `.env` and uses the following variables. Example values and co
 - CODEX_PATH: Path to the `codex` binary. Default `codex`.
 - CODEX_WORKDIR: Working directory for Codex executions (`cwd`). Default `/workspace`.
   - Ensure this directory is writable by the server user; otherwise Codex fails with `Failed to create CODEX_WORKDIR ... Read-only file system`.
-- CODEX_MODEL: String passed as Codex `model`, e.g., `o3`, `o4-mini`, `gpt-5` (see `submodules/codex/docs/config.md`, “model”).
+- CODEX_MODEL: **Deprecated.** Model selection is automatic; setting this variable has no effect (a warning is logged if present).
   - Note: The string is free‑form, but it must be a model name supported by the selected `model_provider` (OpenAI by default).
 - CODEX_SANDBOX_MODE: Sandbox mode. One of: `read-only` | `workspace-write` | `danger-full-access`.
   - For `workspace-write`, the wrapper adds `--config sandbox_workspace_write='{ network_access = <true|false> }'` when the API request specifies `x_codex.network_access`.

--- a/app/config.py
+++ b/app/config.py
@@ -10,7 +10,6 @@ class Settings(BaseSettings):
 
     proxy_api_key: Optional[str] = Field(default=None, alias="PROXY_API_KEY")
     codex_workdir: str = Field(default="/workspace", alias="CODEX_WORKDIR")
-    codex_model: Optional[str] = Field(default=None, alias="CODEX_MODEL")
     codex_path: str = Field(default="codex", alias="CODEX_PATH")
     sandbox_mode: str = Field(default="read-only", alias="CODEX_SANDBOX_MODE")
     reasoning_effort: str = Field(default="medium", alias="CODEX_REASONING_EFFORT")

--- a/app/model_registry.py
+++ b/app/model_registry.py
@@ -1,0 +1,83 @@
+"""Utility helpers for discovering and caching Codex models."""
+
+import logging
+import os
+from typing import List, Optional
+
+from .codex import CodexError, list_codex_models
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "codex-cli"
+_AVAILABLE_MODELS: List[str] = [DEFAULT_MODEL]
+_LAST_ERROR: Optional[str] = None
+_WARNED_LEGACY_ENV = False
+
+
+async def initialize_model_registry() -> List[str]:
+    """Populate the available model list by querying the Codex CLI."""
+
+    global _AVAILABLE_MODELS, _LAST_ERROR
+
+    _warn_if_legacy_env_present()
+
+    try:
+        models = await list_codex_models()
+        if not models:
+            raise CodexError("Codex CLI returned an empty model list")
+        _AVAILABLE_MODELS = models
+        _LAST_ERROR = None
+        logger.info("Loaded %d Codex model(s): %s", len(models), ", ".join(models))
+    except Exception as exc:  # pragma: no cover - startup failure path
+        _LAST_ERROR = str(exc)
+        logger.warning(
+            "Falling back to default model list because Codex model discovery failed: %s",
+            exc,
+        )
+        _AVAILABLE_MODELS = [DEFAULT_MODEL]
+    return list(_AVAILABLE_MODELS)
+
+
+def get_available_models() -> List[str]:
+    """Return a copy of the currently cached model list."""
+
+    return list(_AVAILABLE_MODELS)
+
+
+def get_default_model() -> str:
+    """Return the default model name used when clients omit `model`."""
+
+    return _AVAILABLE_MODELS[0] if _AVAILABLE_MODELS else DEFAULT_MODEL
+
+
+def choose_model(requested: Optional[str]) -> str:
+    """Validate the requested model name and return the selected value."""
+
+    if requested:
+        if requested in _AVAILABLE_MODELS:
+            return requested
+        available = ", ".join(_AVAILABLE_MODELS)
+        raise ValueError(
+            f"Model '{requested}' is not available. Choose one of: {available or 'none'}"
+        )
+    return get_default_model()
+
+
+def get_last_error() -> Optional[str]:
+    """Return the most recent discovery error message (if any)."""
+
+    return _LAST_ERROR
+
+
+def _warn_if_legacy_env_present() -> None:
+    global _WARNED_LEGACY_ENV
+    if _WARNED_LEGACY_ENV:
+        return
+
+    legacy_value = os.getenv("CODEX_MODEL")
+    if legacy_value:
+        logger.warning(
+            "Environment variable CODEX_MODEL is deprecated and ignored. Detected value: %s",
+            legacy_value,
+        )
+    _WARNED_LEGACY_ENV = True

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -17,7 +17,7 @@ class XCodexOptions(BaseModel):
 
 
 class ChatCompletionRequest(BaseModel):
-    model: Optional[str] = Field(default="codex-cli")
+    model: Optional[str] = Field(default=None)
     messages: List[ChatMessage]
     stream: Optional[bool] = False
     temperature: Optional[float] = None
@@ -56,7 +56,7 @@ class ResponsesReasoning(BaseModel):
 
 
 class ResponsesRequest(BaseModel):
-    model: Optional[str] = Field(default="codex-cli")
+    model: Optional[str] = Field(default=None)
     input: Any
     stream: Optional[bool] = False
     reasoning: Optional[ResponsesReasoning] = None

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,7 +8,7 @@ Important: Always install Python libraries inside a virtual environment (venv).
 
 - Base URL: `http://<host>:8000/v1`
 - Auth: `Authorization: Bearer <PROXY_API_KEY>` (you may run without it if configured that way)
-- Model ID: `codex-cli` (display name)
+- Model IDs: discovered at startup by running `codex models list`. Call `GET /v1/models` to inspect the exact names your Codex CLI reports.
 - Submodule: Codex reference lives in `submodules/codex`
 - Supported APIs: `/v1/chat/completions` and minimal `/v1/responses` (see `docs/RESPONSES_API_PLAN.ja.md` – Japanese)
 
@@ -32,10 +32,10 @@ Notes
 ## Supported APIs
 
 - `GET /v1/models`
-  - Example: `{ "data": [{ "id": "codex-cli" }] }`
+  - Example: `{ "data": [{ "id": "o4-mini" }, { "id": "gpt-4.1" }] }`
 - `POST /v1/chat/completions`
   - Input (subset)
-    - `model`: optional; defaults to `codex-cli`
+    - `model`: optional; defaults to the first model reported by Codex at startup
   - `messages`: OpenAI format (`system`/`user`/`assistant`). User messages may include `input_image` parts.
     - `stream`: `true` for SSE streaming
     - `temperature`, `max_tokens`: accepted but ignored for the initial version
@@ -57,9 +57,9 @@ client = OpenAI(
     api_key="YOUR_PROXY_API_KEY",  # if required
 )
 
-# Non-stream
+# Non-stream (replace with a name from GET /v1/models, e.g. "o4-mini")
 resp = client.chat.completions.create(
-    model="codex-cli",
+    model="o4-mini",
     messages=[
         {"role": "system", "content": "You are a helpful coding agent."},
         {"role": "user", "content": "Say hello and exit."},
@@ -69,7 +69,7 @@ print(resp.choices[0].message.content)
 
 # Image input
 resp = client.chat.completions.create(
-    model="codex-cli",
+    model="o4-mini",
     messages=[
         {
             "role": "user",
@@ -84,7 +84,7 @@ print(resp.choices[0].message.content)
 
 # Stream (SSE)
 with client.chat.completions.create(
-    model="codex-cli",
+    model="o4-mini",
     messages=[{"role": "user", "content": "Write 'hello'"}],
     stream=True,
 ) as stream:
@@ -101,7 +101,7 @@ Non‑stream
 ```python
 from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="YOUR_PROXY_API_KEY")
-resp = client.responses.create(model="codex-cli", input="Say hello")
+resp = client.responses.create(model="o4-mini", input="Say hello")
 print(resp.output[0].content[0].text)
 ```
 
@@ -110,7 +110,7 @@ Stream (SSE)
 curl -N \
   -H "Authorization: Bearer $PROXY_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"model":"codex-cli","input":"Say hello","stream":true}' \
+  -d '{"model":"o4-mini","input":"Say hello","stream":true}' \
   http://localhost:8000/v1/responses
 ```
 
@@ -155,7 +155,7 @@ curl -N \
 
 - `PROXY_API_KEY`: auth for this proxy (optional)
 - `CODEX_WORKDIR`: working directory for Codex runs
-- `CODEX_MODEL`: model choice, e.g., `o3` / `o4-mini` / `gpt-5`
+- `CODEX_MODEL`: **deprecated**. Startup now queries available models automatically; setting this variable has no effect other than a warning.
 - `CODEX_PATH`: override path to `codex` binary
 - `CODEX_SANDBOX_MODE`: `read-only` / `workspace-write` / `danger-full-access`
 - `CODEX_REASONING_EFFORT`: `minimal` / `low` / `medium` / `high`

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -14,13 +14,18 @@ This project loads configuration via environment variables. It supports a `.env`
 - `RATE_LIMIT_PER_MINUTE`: Requests per minute allowed per client. `0` disables limiting.
 - `CODEX_PATH`: Path to `codex` binary (default: `codex`).
 - `CODEX_WORKDIR`: Working directory for Codex runs (server enforces `cwd` to this path).
-- `CODEX_MODEL`: Model string passed to Codex (e.g., `o3`, `o4-mini`, `gpt-5`). Must be valid for the configured provider.
 - `CODEX_SANDBOX_MODE`: `read-only` | `workspace-write` | `danger-full-access`.
 - `CODEX_REASONING_EFFORT`: `minimal` | `low` | `medium` | `high`.
 - `CODEX_LOCAL_ONLY`: `0`/`1`. When `1`, the server rejects non‑local provider base URLs.
 - `CODEX_ALLOW_DANGER_FULL_ACCESS`: `0`/`1`. When `1`, the API may request `x_codex.sandbox=danger-full-access`.
 - `CODEX_TIMEOUT`: Server‑side timeout for Codex runs (seconds; default 120).
 - `CODEX_ENV_FILE`: Name of the env file to load (set as an OS env var).
+
+### Model Selection
+
+- The server now discovers available models by invoking the Codex CLI (`codex models list`) during startup.
+- Whatever names Codex reports are exposed through `GET /v1/models`, and clients must use those exact names in the `model` field when calling the API.
+- The legacy `CODEX_MODEL` environment variable is ignored. If it is present the server logs a warning so you can remove it from your configuration.
 
 ## Codex CLI Credentials and Providers
 

--- a/docs/IMPLEMENTATION_PLAN.ja.md
+++ b/docs/IMPLEMENTATION_PLAN.ja.md
@@ -54,7 +54,7 @@
 - FastAPI：HTTP の受け口。SSE にも対応。
 - CodexRunner：`codex exec` を非同期サブプロセスで走らせ、行単位で stdout を流す。失敗時は stderr も吸い上げて整形。
 - PromptBuilder：`messages` を 1 本の指示文にまとめる（`system` を先頭へ）。
-- Config：環境変数で最小制御（例：`CODEX_MODEL`、`CODEX_WORKDIR`、`CODEX_SANDBOX_MODE`、`PROXY_API_KEY`）。
+- Config：環境変数で最小制御（例：`CODEX_WORKDIR`、`CODEX_SANDBOX_MODE`、`PROXY_API_KEY`）。
 - Logger：アプリ側ログ＋Codex セッション JSONL のパスを記録（必要なら後で読み込み）。
 
 ## 4. Codex 呼び出しの取り決め
@@ -97,7 +97,7 @@
 - `CODEX_SANDBOX_MODE`：`read-only` / `workspace-write` / `danger-full-access`（既定は安全側）。
 - `CODEX_REASONING_EFFORT`：`minimal` / `low` / `medium` / `high`（既定は `medium`）。
 - `CODEX_LOCAL_ONLY`：`1` でローカル固定（プロバイダの `base_url` がローカル以外なら 400）。
-- `CODEX_MODEL`：`o3` / `o4-mini` / `gpt-5` 等（任意）。
+- `CODEX_MODEL`：廃止。サーバー起動時に `codex models list` を実行して利用可能なモデルを自動検出する。
 - `CODEX_PATH`：`codex` 実行ファイルへのパスを上書きしたい場合に使用。
 - `CODEX_TIMEOUT`：Codex 実行のタイムアウト秒数（既定 120）。
 - `RATE_LIMIT_PER_MINUTE`：1 分あたりの許可リクエスト数（既定 60）。
@@ -177,7 +177,7 @@ CodexRunner のコマンド
   # 任意: ローカル provider 固定（例: ollama）
   # "--config", "model_provider='ollama'",
   # "--config", "model_providers.ollama='{ name = \"Ollama\", base_url = \"http://localhost:11434/v1\" }'",
-  # "--config", f"model='{os.getenv('CODEX_MODEL','llama3.1')}'",
+  # 旧仕様：環境変数 `CODEX_MODEL` を `--config model` に渡していたが、現在は自動検出されたモデルを使う。
 ]` のように組み立て、空値は落とす。
 - `cwd=CODEX_WORKDIR` を必ず指定。
 - `CODEX_LOCAL_ONLY=1` の場合、`$CODEX_HOME/config.toml` の `model_providers` と `OPENAI_BASE_URL` を検査し、ローカル以外の `base_url` なら実行前に 400 で拒否。


### PR DESCRIPTION
## Summary
- query the Codex CLI at startup to populate a model registry and expose the discovered names through the API
- remove reliance on CODEX_MODEL and pass the validated request model name to codex exec calls
- refresh documentation and the sample env file to describe automatic model detection and the legacy variable deprecation

## Testing
- python -m compileall app
- python -m compileall app/model_registry.py
- python -m compileall app/codex.py

------
https://chatgpt.com/codex/tasks/task_e_68ca3e10345c832f85b9db6048f2d1c5