### PR TITLE
Add env toggle for reasoning output

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ CODEX_SANDBOX_MODE=read-only
 # Reasoning effort for the model (minimal | low | medium | high)
 CODEX_REASONING_EFFORT=medium
 
+# Whether to expose the model's reasoning/thinking text in API responses (true | false)
+# Default true to preserve legacy behavior. Set to false to strip `<think>` blocks and similar output.
+CODEX_EXPOSE_REASONING=true
+
 # Restrict remote model providers to LOCAL ONLY (true | false)
 # Default and recommended: false (to use the built‑in OpenAI provider).
 # Set true only if you want to hard‑enforce local providers (e.g., Ollama).

--- a/README.ja.md
+++ b/README.ja.md
@@ -140,6 +140,7 @@ Responses API 互換は最小実装済み（非ストリーム/ストリーム�
 - CODEX_SANDBOX_MODE: サンドボックスモード。`read-only` / `workspace-write` / `danger-full-access` のいずれか。
   - `workspace-write` の場合、API リクエストで `x_codex.network_access` が指定されると `--config sandbox_workspace_write='{ network_access = <true|false> }'` を付与します。
 - CODEX_REASONING_EFFORT: 推論強度。`minimal` / `low` / `medium` / `high`（既定は `medium`）。
+- CODEX_EXPOSE_REASONING: `true` / `false`。既定は `true`（従来通り思考過程を返します）。`false` にすると Codex が出力する思考テキスト（例：`<think>` ブロック）を API 応答から除去します。
 - CODEX_LOCAL_ONLY: `0` または `1`。既定は `0`（推奨）。
   - `1` にするとローカル以外の `base_url`（localhost/127.0.0.1/[::1]/UNIX ソケット以外）のモデルプロバイダを 400 で拒否します。
   - サーバーは `$CODEX_HOME/config.toml` の `model_providers` と組み込み `openai` プロバイダの `OPENAI_BASE_URL` を検証し、不明な設定は安全側で拒否します。

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This server reads `.env` and uses the following variables. Example values and co
 - CODEX_SANDBOX_MODE: Sandbox mode. One of: `read-only` | `workspace-write` | `danger-full-access`.
   - For `workspace-write`, the wrapper adds `--config sandbox_workspace_write='{ network_access = <true|false> }'` when the API request specifies `x_codex.network_access`.
 - CODEX_REASONING_EFFORT: Reasoning effort. One of: `minimal` | `low` | `medium` | `high` (default `medium`).
+- CODEX_EXPOSE_REASONING: `true`/`false`. Default `true` to match prior behavior. Set to `false` to remove Codex reasoning/thinking output (e.g., `<think>` blocks) from API responses.
 - CODEX_LOCAL_ONLY: `0`/`1`. Default `0` (recommended).
   - If `1`, any non‑local model provider `base_url` (not localhost/127.0.0.1/[::1]/unix) is rejected with 400.
   - The server checks `$CODEX_HOME/config.toml` `model_providers` and the built‑in `openai` provider’s `OPENAI_BASE_URL`. Unknown/missing settings are rejected conservatively.

--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     local_only: bool = Field(default=False, alias="CODEX_LOCAL_ONLY")
     timeout_seconds: int = Field(default=120, alias="CODEX_TIMEOUT")
     rate_limit_per_minute: int = Field(default=60, alias="RATE_LIMIT_PER_MINUTE")
+    expose_reasoning: bool = Field(default=True, alias="CODEX_EXPOSE_REASONING")
     # Allow server to honor x_codex.sandbox == "danger-full-access" requests.
     # When false, such requests are blocked if received (unless CODEX_LOCAL_ONLY is also false
     # in older behavior). Prefer enabling this explicitly for safety.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -19,6 +19,7 @@ This project loads configuration via environment variables. It supports a `.env`
   - API 専用の `config.toml` や MCP 設定を分離したい場合に利用します（CLI を直接使う環境と分けられます）。
 - `CODEX_SANDBOX_MODE`: `read-only` | `workspace-write` | `danger-full-access`.
 - `CODEX_REASONING_EFFORT`: `minimal` | `low` | `medium` | `high`.
+- `CODEX_EXPOSE_REASONING`: `0`/`1`. When `0`, the API strips Codex `<think>`/reasoning segments before returning responses. Default `1` (legacy behavior: include thinking text).
 - `CODEX_LOCAL_ONLY`: `0`/`1`. When `1`, the server rejects non‑local provider base URLs.
 - `CODEX_ALLOW_DANGER_FULL_ACCESS`: `0`/`1`. When `1`, the API may request `x_codex.sandbox=danger-full-access`.
 - `CODEX_TIMEOUT`: Server‑side timeout for Codex runs (seconds; default 120).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = workspace

--- a/tests/test_reasoning_filter.py
+++ b/tests/test_reasoning_filter.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.codex import ReasoningStreamFilter, strip_reasoning_text
+
+
+def test_reasoning_stream_filter_passthrough():
+    filt = ReasoningStreamFilter(include_reasoning=True)
+    assert filt.process("Hello world\n") == "Hello world\n"
+
+
+def test_reasoning_stream_filter_think_blocks_removed():
+    filt = ReasoningStreamFilter(include_reasoning=False)
+    assert filt.process("<think>internal step\n") is None
+    assert filt.process("more thinking</think>\n") is None
+    assert filt.process("Final answer\n") == "Final answer\n"
+
+
+def test_reasoning_stream_filter_json_reasoning_removed():
+    filt = ReasoningStreamFilter(include_reasoning=False)
+    reasoning_json = '{"type": "reasoning", "text": "internal"}\n'
+    assert filt.process(reasoning_json) is None
+
+
+def test_reasoning_stream_filter_json_final_text():
+    filt = ReasoningStreamFilter(include_reasoning=False)
+    final_json = '{"type": "message", "text": "Final"}\n'
+    assert filt.process(final_json) == "Final\n"
+
+
+def test_strip_reasoning_text_think_block_removed():
+    text = "<think>internal</think>\nAnswer"
+    assert strip_reasoning_text(text, include_reasoning=False) == "Answer"
+
+
+def test_strip_reasoning_text_json_removed():
+    json_text = (
+        '{"role":"assistant","content":['
+        '{"type":"reasoning","text":"internal"},'
+        '{"type":"output_text","text":"Answer"}'
+        "]}"
+    )
+    assert strip_reasoning_text(json_text, include_reasoning=False) == "Answer"
+
+
+def test_strip_reasoning_text_passthrough_when_enabled():
+    text = "<think>internal</think>\nAnswer"
+    assert strip_reasoning_text(text, include_reasoning=True) == text


### PR DESCRIPTION
## Summary
- add CODEX_EXPOSE_REASONING setting and document the new toggle
- filter Codex streaming and non-streaming outputs when reasoning exposure is disabled
- cover reasoning filtering with unit tests and ignore the workspace folder during pytest collection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbd92293f4832fa03810fbc54ad588