### PR TITLE
fix: expose codex deployments in /v1/models

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,6 +9,7 @@ Important: Always install Python libraries inside a virtual environment (venv).
 - Base URL: `http://<host>:8000/v1`
 - Auth: `Authorization: Bearer <PROXY_API_KEY>` (you may run without it if configured that way)
 - Model IDs: discovered at startup by running `codex models list`. Call `GET /v1/models` to inspect the exact names your Codex CLI reports.
+  - When the CLI only exposes deployments/variants (e.g. `{"id": "gpt-5", "deployment": "codex"}`), the wrapper expands them into aliases such as `gpt-5-codex` so existing clients continue to work.
   - You can append ` minimal` / ` low` / ` medium` / ` high` to those model IDs to set the reasoning effort (for example: `gpt-5-codex high`).
 - Submodule: Codex reference lives in `submodules/codex`
 - Supported APIs: `/v1/chat/completions` and minimal `/v1/responses` (see `docs/RESPONSES_API_PLAN.ja.md` – Japanese)

--- a/tests/test_codex_model_listing.py
+++ b/tests/test_codex_model_listing.py
@@ -1,0 +1,40 @@
+import json
+
+from app import codex
+
+
+def test_parse_model_listing_includes_codex_variants_from_json():
+    payload = json.dumps(
+        {
+            "data": [
+                {"id": "gpt-5", "deployment": "codex"},
+                {"id": "gpt-5-mini", "deployments": ["codex", "default"]},
+                {"id": "gpt-5-pro", "variants": [{"id": "codex-latest"}]},
+                {"id": "o4-mini", "deployment": "default"},
+            ]
+        }
+    )
+
+    models = codex._parse_model_listing(payload)
+
+    assert "gpt-5" in models
+    assert models.count("gpt-5-codex") == 1
+    assert models.count("gpt-5-mini-codex") == 1
+    assert "gpt-5-pro-codex-latest" in models
+    assert "o4-mini" in models
+    assert "o4-mini-codex" not in models
+
+
+def test_parse_model_listing_infers_codex_from_plaintext():
+    raw = """
+    Available models:
+      gpt-5 codex default
+      gpt-5-mini codex
+      o4-mini default
+    """
+
+    models = codex._parse_model_listing(raw)
+
+    assert "gpt-5-codex" in models
+    assert "gpt-5-mini-codex" in models
+    assert "o4-mini-codex" not in models


### PR DESCRIPTION
## Summary
- parse Codex CLI JSON/text listings for deployment metadata and emit codex aliases such as gpt-5-codex
- normalize timestamped "User instructions" markers so they stay hidden after the parser refactor
- document the alias expansion and add regression tests for both the JSON and plaintext model listings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccffe075cc832f933096aca8f42e46