### PR TITLE
docs: clarify structured output limitation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -135,6 +135,7 @@ client = OpenAI(base_url="http://localhost:8000/v1", api_key="YOUR_PROXY_API_KEY
 
 
 Responses API 互換は最小実装済み（非ストリーム/ストリーム）。詳細と今後の拡張は `docs/RESPONSES_API_PLAN.ja.md` を参照。
+Structured output（`response_format` や JSON Schema）には Codex CLI が文字列のみを返す仕様上対応しておらず、本ラッパーでも非対応です。
 
 ## 環境変数
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ Sample response on 2025-09-18 (call the endpoint in your environment to confirm)
 
 You can append ` minimal` / ` low` / ` medium` / ` high` to any of the above IDs to override reasoning effort inline (for example: `gpt-5-codex high`).
 
- Minimal Responses API compatibility (non‑stream/stream) is implemented; see `docs/RESPONSES_API_PLAN.ja.md` (Japanese) for details and future work.
+Minimal Responses API compatibility (non‑stream/stream) is implemented; see `docs/RESPONSES_API_PLAN.ja.md` (Japanese) for details and future work.
+Structured output features such as `response_format`/JSON Schema are not supported because the Codex CLI only returns plain text and this wrapper normalizes those results into strings.
 
 ## Environment Variables (Authoritative)
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -48,6 +48,7 @@ Notes
     - `Content-Type: text/event-stream`
     - Lines as `data: {chunk}`, end with `data: [DONE]`
     - JSON lines are preferred; we emit their `text`/`content` as `choices[0].delta.content`. Non‑JSON lines are concatenated as text fallback.
+  - Structured output features such as `response_format`/JSON Schema are not supported because the Codex CLI emits plain text and the wrapper normalizes those values into strings.
 
 ## Examples (Python / OpenAI SDK)
 

--- a/docs/RESPONSES_API_PLAN.ja.md
+++ b/docs/RESPONSES_API_PLAN.ja.md
@@ -37,7 +37,7 @@
 オプション・マッピング
 - `reasoning.effort`（`minimal|low|medium|high`）→ `x_codex.reasoning_effort`
 - `stream: true/false` → SSE 出力の有無
-  - 以下は一旦未対応（受け取って無視／400 にしない）：`instructions`、`modalities`、`audio`、`tools`、`metadata`、`text.format`（Structured Output）
+- 以下は一旦未対応（受け取って無視／400 にしない）：`instructions`、`modalities`、`audio`、`tools`、`metadata`、`text.format`（Structured Output。Codex CLI が構造化オブジェクトを返さず文字列のみを出力するため伝搬経路がない）
 
 ## レスポンス構造（非ストリーム）
 
@@ -126,7 +126,7 @@ Codex の出力行の扱い
 
 ## 互換性と制約（当面）
 
-- 未対応: ツール呼び出し、画像・音声、Structured Output（`text.format`）、function/tool outputs、parallel responses。
+- 未対応: ツール呼び出し、画像・音声、Structured Output（`text.format`。Codex CLI が文字列のみを返す仕様のため非対応）、function/tool outputs、parallel responses。
 - モデル/プロバイダ:
   - 既定は OpenAI（`OPENAI_API_KEY` がある場合）。`CODEX_LOCAL_ONLY=1` の場合はローカル以外の `base_url` を拒否。
 - セキュリティ: 既存の `PROXY_API_KEY`、レート制限、サンドボックス方針に従う。


### PR DESCRIPTION
## Summary
- note in both README files that structured output is unavailable because the Codex CLI only emits plain text
- update the English agent guide and Japanese Responses plan to explain the CLI limitation around structured output

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cdd623209c832f9c6bbf063903f1fd