### PR TITLE
Add auto-restart support for Docker deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.gitmodules
+.gitignore
+__pycache__
+*.py[cod]
+*.swp
+.env
+.env.*
+.venv
+venv
+workspace/*
+!workspace/codex_profile/
+.docs_cache
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG CODEX_VERSION=latest
+
+# Install system dependencies and Codex CLI binary
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        passwd; \
+    rm -rf /var/lib/apt/lists/*; \
+    case "${TARGETOS:-linux}-${TARGETARCH:-amd64}" in \
+        linux-amd64) codex_arch="x86_64-unknown-linux-musl" ;; \
+        linux-arm64) codex_arch="aarch64-unknown-linux-musl" ;; \
+        *) echo "Unsupported architecture: ${TARGETOS:-linux}-${TARGETARCH:-amd64}" >&2; exit 1 ;; \
+    esac; \
+    if [ "${CODEX_VERSION}" = "latest" ]; then \
+        codex_url="https://github.com/openai/codex/releases/latest/download/codex-${codex_arch}.tar.gz"; \
+    else \
+        codex_url="https://github.com/openai/codex/releases/download/${CODEX_VERSION}/codex-${codex_arch}.tar.gz"; \
+    fi; \
+    curl -fsSL "$codex_url" -o /tmp/codex.tar.gz; \
+    tar -xzf /tmp/codex.tar.gz -C /usr/local/bin; \
+    mv /usr/local/bin/codex-${codex_arch} /usr/local/bin/codex; \
+    chmod +x /usr/local/bin/codex; \
+    rm /tmp/codex.tar.gz
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN set -eux; \
+    mkdir -p /workspace /home/appuser/.codex; \
+    if ! id appuser >/dev/null 2>&1; then useradd --create-home --shell /bin/bash appuser; fi; \
+    chown -R appuser:appuser /app /workspace /home/appuser/.codex
+
+USER appuser
+
+ENV CODEX_WORKDIR=/workspace \
+    PATH="/home/appuser/.local/bin:${PATH}"
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  codex-wrapper:
+    build:
+      context: .
+    image: codex-wrapper:local
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      PROXY_API_KEY: ${PROXY_API_KEY:-}
+      CODEX_LOCAL_ONLY: ${CODEX_LOCAL_ONLY:-0}
+      CODEX_ALLOW_DANGER_FULL_ACCESS: ${CODEX_ALLOW_DANGER_FULL_ACCESS:-0}
+      CODEX_WORKDIR: /workspace
+    volumes:
+      - workspace-data:/workspace
+      - codex-home:/home/appuser/.codex
+    env_file:
+      - .env
+volumes:
+  workspace-data:
+  codex-home:

--- a/docs/DOCKER.ja.md
+++ b/docs/DOCKER.ja.md
@@ -1,0 +1,65 @@
+# Docker デプロイメント
+
+このリポジトリには FastAPI ラッパーと Codex CLI をまとめて含む `Dockerfile` が追加されました。イメージはビルド時に公開済みの Codex バイナリを取得し、リポジトリ（`submodules/codex` を含む）をコピーするため、コンテナ内から上流ドキュメントも参照できます。
+
+> **前提:** ビルド前に Codex サブモジュールを初期化してください。
+>
+> ```bash
+> git submodule update --init --recursive
+> ```
+
+## イメージのビルド
+
+```bash
+docker build -t codex-wrapper .
+```
+
+ビルドでは Docker BuildKit が渡す `TARGETOS` / `TARGETARCH` を利用して適切な Codex バイナリをダウンロードします。Linux の `amd64` と `arm64` をサポートしています。`--build-arg CODEX_VERSION=vX.Y.Z` を指定すると取得する Codex リリースを上書きできます（既定の `latest` は最新リリースを使用）。
+
+## 実行時レイアウト
+
+- Codex 実行用のワークディレクトリ: `/workspace`（`CODEX_WORKDIR` で変更可能）。
+- Codex CLI のホーム: `/home/appuser/.codex`。`auth.json` や `config.toml`、MCP 設定を永続化するにはこのパスをマウントしてください。
+- API は `uvicorn app.main:app` でポート `8000` をリッスンします。
+
+資格情報を保持し、Codex に書き込み可能なサンドボックスを与えるにはコンテナ起動時にボリュームをマウントします。
+
+```bash
+docker run \
+  --rm \
+  --restart unless-stopped \
+  -p 8000:8000 \
+  -v "$PWD/workspace-data:/workspace" \
+  -v "$HOME/.codex:/home/appuser/.codex" \
+  --env-file ./.env \
+  codex-wrapper
+```
+
+環境変数の詳細は [`docs/ENV.md`](./ENV.md) を参照してください。例えば `PROXY_API_KEY`、`CODEX_LOCAL_ONLY`、`CODEX_ALLOW_DANGER_FULL_ACCESS` などを必要に応じて設定します。`CODEX_HOME` をエクスポートすれば Codex の状態保存先を変更できます。
+
+> **移行メモ:** 既存の `docker run` コマンドで `--restart` を付けていなかった場合は、`--restart unless-stopped` を追記しておくとホスト再起動や Docker デーモン再起動後も自動的に立ち上がります。
+
+## 自動再起動付きの Docker Compose
+
+宣言的に運用したい場合は、自動再起動を有効化した `docker-compose.yml` をリポジトリに追加しました。
+
+```bash
+docker compose up -d
+```
+
+Compose ファイルは `codex-wrapper:local` イメージをビルドし、`/workspace` と `/home/appuser/.codex` に永続ボリュームを割り当て、`restart: unless-stopped` を適用します。必要に応じてポート、バインドマウント、環境変数を調整してください。
+
+## コンテナ内での Codex 動作確認
+
+コンテナを起動後、シェルに入って CLI が動作することを確認できます。
+
+```bash
+docker exec -it <container-id> codex --help
+```
+
+上記コマンドはダウンロードしたリリースの Codex CLI ヘルプを表示します。
+
+## イメージの更新
+
+- 上流の Codex CLI が更新されたり、ラッパーの変更を取得した場合はイメージを再ビルドしてください。
+- フォークを運用する場合は `submodules/codex` ディレクトリを更新し、オフライン環境でも上流ドキュメントを参照できるようにしておくと便利です。

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,65 @@
+# Docker Deployment
+
+This repository now ships a `Dockerfile` that bundles the FastAPI wrapper together with the Codex CLI. The image installs the published Codex binary during build time and copies the repository (including the `submodules/codex` checkout) so you can inspect upstream documentation from inside the container.
+
+> **Prerequisite:** Make sure the Codex submodule is populated before building.
+>
+> ```bash
+> git submodule update --init --recursive
+> ```
+
+## Building the image
+
+```bash
+docker build -t codex-wrapper .
+```
+
+The build uses `TARGETOS`/`TARGETARCH` arguments supplied by Docker BuildKit to download the correct Codex binary. Linux `amd64` and `arm64` are supported. You can override the Codex release by passing `--build-arg CODEX_VERSION=vX.Y.Z`; the default `latest` tracks the newest GitHub release.
+
+## Runtime layout
+
+- Default working directory for Codex runs: `/workspace` (configurable via `CODEX_WORKDIR`).
+- Codex CLI home: `/home/appuser/.codex`. Mount this path to persist `auth.json`, `config.toml`, and MCP settings.
+- The API listens on port `8000` with `uvicorn app.main:app`.
+
+To retain credentials and give Codex a writable sandbox, mount volumes when you start the container:
+
+```bash
+docker run \
+  --rm \
+  --restart unless-stopped \
+  -p 8000:8000 \
+  -v "$PWD/workspace-data:/workspace" \
+  -v "$HOME/.codex:/home/appuser/.codex" \
+  --env-file ./.env \
+  codex-wrapper
+```
+
+Environment variables follow the definitions in [`docs/ENV.md`](./ENV.md). For example, set `PROXY_API_KEY`, `CODEX_LOCAL_ONLY`, or `CODEX_ALLOW_DANGER_FULL_ACCESS` as needed. You may also export `CODEX_HOME` if you prefer a different location for Codex state.
+
+> **Upgrade note:** Existing users who previously ran the container without `--restart` should add `--restart unless-stopped` to keep the API online after host reboots or daemon restarts.
+
+## Docker Compose with auto-restart
+
+If you prefer declarative management, the repository now includes a `docker-compose.yml` that enables automatic restarts by default:
+
+```bash
+docker compose up -d
+```
+
+The compose file builds `codex-wrapper:local`, mounts persistent volumes for `/workspace` and `/home/appuser/.codex`, and applies `restart: unless-stopped`. Adjust the exposed port, bind mounts, or environment variables to match your deployment needs.
+
+## Verifying Codex inside the container
+
+After launching the container you can open a shell and confirm the CLI works:
+
+```bash
+docker exec -it <container-id> codex --help
+```
+
+This prints the Codex CLI usage banner from the downloaded release.
+
+## Updating the image
+
+- Rebuild the image whenever the upstream Codex CLI changes or when you pull new wrapper updates.
+- If you maintain your own fork, keep the `submodules/codex` directory updated so developers can read the bundled upstream documentation even when offline.


### PR DESCRIPTION
## Summary
- add a docker-compose.yml with restart policies and persistent volumes
- document the --restart flag and compose workflow in English and Japanese guides

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd9950310832f8986065cd192c3ec